### PR TITLE
Return yields as array

### DIFF
--- a/lib/yaml/safe_load_stream.rb
+++ b/lib/yaml/safe_load_stream.rb
@@ -12,16 +12,16 @@ module YAMLSafeLoadStream
   # @yield [document] each document in the stream is yielded if a block is given
   # @return [Array] when a block is not given, returns an Array of documents
   module_function def safe_load_stream(yaml, filename = nil)
-    streams = []
+    result = []
     ::YAML.parse_stream(yaml, filename) do |stream|
       raise_if_tags(stream, filename)
       if block_given?
-        yield stream.to_ruby
+        result << yield(stream.to_ruby)
       else
-        streams << stream.to_ruby
+        result << stream.to_ruby
       end
     end
-    streams unless block_given?
+    result
   end
 
   module_function def raise_if_tags(obj, filename = nil, doc_num = 1)

--- a/lib/yaml/safe_load_stream.rb
+++ b/lib/yaml/safe_load_stream.rb
@@ -15,7 +15,11 @@ module YAMLSafeLoadStream
     result = []
     ::YAML.parse_stream(yaml, filename) do |stream|
       raise_if_tags(stream, filename)
-      result << block_given? ? yield(stream.to_ruby) : stream.to_ruby
+      result << if block_given?
+                  yield(stream.to_ruby)
+                else
+                  stream.to_ruby
+                end
     end
     result
   end

--- a/lib/yaml/safe_load_stream.rb
+++ b/lib/yaml/safe_load_stream.rb
@@ -15,11 +15,7 @@ module YAMLSafeLoadStream
     result = []
     ::YAML.parse_stream(yaml, filename) do |stream|
       raise_if_tags(stream, filename)
-      if block_given?
-        result << yield(stream.to_ruby)
-      else
-        result << stream.to_ruby
-      end
+      result << block_given? ? yield(stream.to_ruby) : stream.to_ruby
     end
     result
   end

--- a/lib/yaml/safe_load_stream/version.rb
+++ b/lib/yaml/safe_load_stream/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module YAMLSafeLoadStream
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/yaml/safe_load_stream_spec.rb
+++ b/spec/yaml/safe_load_stream_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe YAMLSafeLoadStream do
       expect(docs.first['hello']).to eq 'world'
       expect(docs.last['hello']).to eq 'universe'
     end
+
+    it 'returns the result of yields as array' do
+      docs = YAMLSafeLoadStream.safe_load_stream(multidoc_stream) do |doc|
+        expect(doc).to be_a Hash
+        doc
+      end
+
+      expect(docs.first['hello']).to eq 'world'
+      expect(docs.last['hello']).to eq 'universe'
+    end
   end
 
   context 'used without a block' do


### PR DESCRIPTION
When used in block mode, you would expect this to work:

```ruby
stuff = YAML.safe_load_stream(foofoo) do |doc|
  doc.compact
end
# stuff now includes each doc.compact
```

And with this PR it works.
